### PR TITLE
Several HTML Entity Bug fixes

### DIFF
--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -885,7 +885,7 @@ proc renderInlineText(ctx: MarkdownContext, inlineText: string): string =
 proc renderLinkTitle(text: string): string =
   var title: string
   if text != "":
-    fmt(" title=\"{text.escapeBackslash.escapeAmpersandSeq.escapeQuote}\"")
+    fmt(" title=\"{text.escapeBackslash.escapeHTMLEntity.escapeAmpersandSeq.escapeQuote}\"")
   else:
     ""
 

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -795,7 +795,10 @@ proc renderIndentedBlockCode(code: string): string =
 proc renderParagraph(ctx: MarkdownContext, paragraph: Paragraph): string =
   for token in paragraph.inlines:
     result &= renderToken(ctx, token)
-  result = fmt"<p>{result}</p>"
+  if paragraph.inlines.len == 1 and paragraph.inlines[0].type == MarkdownTokenType.InlineHTML:
+    return result
+  else:
+    result = fmt"<p>{result}</p>"
 
 proc renderThematicBreak(): string =
   result = "<hr />"

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -429,7 +429,7 @@ proc escapeAmpersandSeq*(doc: string): string =
 
 proc escapeCode*(doc: string): string =
   ## Make code block in markdown document HTML-safe.
-  result = doc.escapeTag.escapeAmpersandSeq
+  result = doc.escapeAmpersandChar.escapeTag
 
 const IGNORED_HTML_ENTITY = ["&lt;", "&gt;", "&amp;"]
 

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -897,8 +897,9 @@ proc renderAutoLink(ctx: MarkdownContext, link: Link): string =
   elif link.isEmail:
     result = fmt"""<a href="mailto:{link.url}">{link.text}</a>"""
   else:
-    var url = link.url.escapeBackslash.escapeLinkUrl.escapeAmpersandSeq
-    result = fmt"""<a href="{url}">{url}</a>"""
+    var text = link.url.escapeAmpersandSeq
+    var url = link.url.escapeLinkUrl
+    result = fmt"""<a href="{url}">{text}</a>"""
 
 proc renderInlineLink(ctx: MarkdownContext, link: Link): string =
   var refId = link.text.toLower.replace(re"\s+", " ")

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -394,6 +394,7 @@ proc preprocessing*(doc: string): string =
   result = result.replace(re"^ {1,3}\t", "    ")
   result = result.replace("\u2424", " ")
   result = result.replace("\u0000", "\uFFFD")
+  result = result.replace("&#0;", "&#XFFFD;")
   result = result.replace(re(r"^ +$", {RegexFlag.reMultiLine}), "")
 
 proc escapeTag*(doc: string): string =

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -798,10 +798,7 @@ proc renderIndentedBlockCode(code: string): string =
 proc renderParagraph(ctx: MarkdownContext, paragraph: Paragraph): string =
   for token in paragraph.inlines:
     result &= renderToken(ctx, token)
-  if paragraph.inlines.len == 1 and paragraph.inlines[0].type == MarkdownTokenType.InlineHTML:
-    return result
-  else:
-    result = fmt"<p>{result}</p>"
+  result = fmt"<p>{result}</p>"
 
 proc renderThematicBreak(): string =
   result = "<hr />"

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -785,7 +785,7 @@ proc renderFencingBlockCode(fence: Fence): string =
   if fence.lang == "":
     lang = ""
   else:
-    lang = fmt(" class=\"language-{escapeBackslash(fence.lang)}\"")
+    lang = fmt(" class=\"language-{escapeHTMLEntity(escapeBackslash(fence.lang))}\"")
   result = fmt("""<pre><code{lang}>{escapeCode(fence.code)}
 </code></pre>""")
 

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -441,6 +441,8 @@ proc escapeHTMLEntity*(doc: string): string =
       var utf8Char = entity[1 .. entity.len-2].entityToUtf8
       if utf8Char != "":
         result = result.replace(re(entity), utf8Char)
+      else:
+        result = result.replace(re(entity), entity.escapeAmpersandChar)
 
 proc escapeLinkUrl*(url: string): string =
   encodeUrl(url.escapeHTMLEntity, usePlus=false).replace("%40", "@"

--- a/tests/testgfm.nim
+++ b/tests/testgfm.nim
@@ -4,6 +4,7 @@ import re, strutils, os, json, strformat
 import markdown
 
 let KNOW_ISSUES = [
+  314, # MINOR: we convert html entity via htmlparser.entityToUtf8. Some entities are not supported.
   334, # *foo`*`: backtick should have higher precedence than emphasis.
   335, # [not a `link](/foo`): backtick should have higher precedence than inline link.
   339, # <http://foo.bar.`baz>`: backtick should be escaped in autolink.


### PR DESCRIPTION
* replace insecure `&#0;` to replacement utf8 codepoint.
* escape html entities in fences, link.