### PR TITLE
Optimize string slicing.

### DIFF
--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -1296,7 +1296,7 @@ proc consumeBlockquoteMarker(doc: string): string =
     result &= s
 
 method parse*(this: BlockquoteParser, doc: string, start: int): ParseResult =
-  let markerContent = re(r"^(( {0,3}>([^\n]*(?:\n|$)))+)")
+  let markerContent = re(r"(( {0,3}>([^\n]*(?:\n|$)))+)")
   var matches: array[3, string]
   var pos = start
   var size = -1
@@ -1305,7 +1305,7 @@ method parse*(this: BlockquoteParser, doc: string, start: int): ParseResult =
   var chunks: seq[Chunk]
 
   while pos < doc.len:
-    size = doc.since(pos).matchLen(markerContent, matches=matches)
+    size = doc.matchLen(markerContent, matches, pos)
 
     if size == -1:
       break

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -640,11 +640,11 @@ proc parseLoose(token: Token): bool =
   return false
 
 proc parseOrderedListItem*(doc: string, start=0, marker: var string, listItemDoc: var string, index: var int = 1): int =
-  let markerRegex = re"^(?P<leading> {0,3})(?<index>\d{1,9})(?P<marker>\.|\))(?: *$| *\n|(?P<indent> +)([^\n]+(?:\n|$)))"
+  let markerRegex = re"(?P<leading> {0,3})(?<index>\d{1,9})(?P<marker>\.|\))(?: *$| *\n|(?P<indent> +)([^\n]+(?:\n|$)))"
   var matches: array[5, string]
   var pos = start
 
-  var firstLineSize = doc[pos ..< doc.len].matchLen(markerRegex, matches=matches)
+  var firstLineSize = doc.matchLen(markerRegex, matches, pos)
   if firstLineSize == -1:
     return -1
 
@@ -671,7 +671,7 @@ proc parseOrderedListItem*(doc: string, start=0, marker: var string, listItemDoc
 
   var size = 0
   while pos < doc.len:
-    size = doc[pos ..< doc.len].matchLen(re(r"^(?:\s*| {" & fmt"{padding}" & r"}([^\n]*))(\n|$)"), matches=matches)
+    size = doc.matchLen(re(r"(?:\s*| {" & fmt"{padding}" & r"}([^\n]*))(\n|$)"), matches, pos)
     if size != -1:
       listItemDoc &= matches[0]
       listItemDoc &= matches[1]
@@ -694,15 +694,15 @@ proc parseOrderedListItem*(doc: string, start=0, marker: var string, listItemDoc
 
 proc parseUnorderedListItem*(doc: string, start=0, marker: var string, listItemDoc: var string): int =
   #  thematic break takes precedence over list item.
-  if doc[start ..< doc.len].matchLen(re(r"^" & THEMATIC_BREAK_RE)) != -1:
+  if doc.matchLen(re(THEMATIC_BREAK_RE), start) != -1:
     return -1
 
   # OL needs to include <empty> as well.
-  let markerRegex = re"^(?P<leading> {0,3})(?P<marker>[*\-+])(?:(?P<empty> *(?:\n|$))|(?<indent>(?: +|\t+))([^\n]+(?:\n|$)))"
+  let markerRegex = re"(?P<leading> {0,3})(?P<marker>[*\-+])(?:(?P<empty> *(?:\n|$))|(?<indent>(?: +|\t+))([^\n]+(?:\n|$)))"
   var matches: array[5, string]
   var pos = start
 
-  var firstLineSize = doc[pos ..< doc.len].matchLen(markerRegex, matches=matches)
+  var firstLineSize = doc.matchLen(markerRegex, matches, pos)
   if firstLineSize == -1:
     return -1
 
@@ -732,7 +732,7 @@ proc parseUnorderedListItem*(doc: string, start=0, marker: var string, listItemD
 
   var size = 0
   while pos < doc.len:
-    size = doc[pos ..< doc.len].matchLen(re(r"^(?:[ \t]*| {" & fmt"{padding}" & r"}([^\n]*))(\n|$)"), matches=matches)
+    size = doc.matchLen(re(r"(?:[ \t]*| {" & fmt"{padding}" & r"}([^\n]*))(\n|$)"), matches, pos)
     if size != -1:
       listItemDoc &= matches[0]
       listItemDoc &= matches[1]


### PR DESCRIPTION
As [revealed](https://github.com/soasme/nim-markdown/files/5755247/profile_results.txt) in #48, `since()` is the most frequently called proc. This PR is aimed to eliminate all `since()` calls.

Comparing to the current master, it provides roughly 40% performance improvement when running against [out2.txt](https://github.com/soasme/nim-markdown/files/5755244/out2.txt), a 100k doc.

Before:
```
$ nim c -d:release src/markdown.nim && time ./src/markdown < /tmp/out2.txt
real	0m1.751s
user	0m0.946s
sys	0m0.013s
```
After:
```
real	0m1.663s
user	0m0.535s
sys	0m0.016s
```