### PR TITLE
Performance optimization: eliminate substr calls in various places.

### DIFF
--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -1265,7 +1265,6 @@ method parse*(this: HtmlBlockParser, doc: string, start: int): ParseResult {.loc
   var size = -1
 
   let firstLineEnd = findFirstLine(doc, start)
-  let firstLine = substr(doc, start, firstLineEnd)
 
   var startRe: Regex = nil
   var endRe: Regex = nil
@@ -1287,6 +1286,7 @@ method parse*(this: HtmlBlockParser, doc: string, start: int): ParseResult {.loc
       pos: firstLineEnd
     )
 
+  let firstLine = substr(doc, start, firstLineEnd)
   pos = firstLine.len
 
   # XXX: performance improvement: no need to allocate string per line.

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -1243,10 +1243,9 @@ method parse*(this: HtmlBlockParser, doc: string, start: int): ParseResult {.loc
   var html = ""
   var pos = 0
   var size = -1
-  let docLines = substr(doc, start, doc.len-1).splitLines(keepEol=true)
-  if docLines.len == 0:
-    return ParseResult(token: nil, pos: -1)
-  let firstLine = docLines[0]
+
+  let rest = substr(doc, start, doc.len-1)
+  let firstLine = rest.firstLine
 
   var startRe: Regex = nil
   var endRe: Regex = nil
@@ -1270,7 +1269,8 @@ method parse*(this: HtmlBlockParser, doc: string, start: int): ParseResult {.loc
     )
   else:
     pos = firstLine.len
-  for line in docLines[1 ..< docLines.len]:
+
+  for line in rest.restLines:
     pos += line.len
     html &= line
     if line.find(endRe) != -1:

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -1316,9 +1316,10 @@ method parse*(this: HtmlBlockParser, doc: string, start: int): ParseResult {.loc
     pos: start+pos
   )
 
-const rBlockquoteMarker = r"^( {0,3}>)"
+const rBlockquoteMarker = r"( {0,3}>)"
 
-proc isBlockquote*(s: string): bool = s.contains(re(rBlockquoteMarker))
+proc isBlockquote*(s: string, start: int = 0): bool =
+  s.match(re(rBlockquoteMarker), start)
 
 proc consumeBlockquoteMarker(doc: string): string =
   var r: string

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -1519,9 +1519,9 @@ proc isOlNo1ListItem*(doc: string): bool =
   )
 
 method parse*(this: ParagraphParser, doc: string, start: int): ParseResult =
+  let firstLineSize = findFirstLine(doc, start)
+  var size: int = firstLineSize+1
   let rest = substr(doc, start, doc.len-1)
-  let firstLine = rest.firstLine
-  var size: int = firstLine.len
 
   for line in rest.restLines:
     # Special cases.

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -970,7 +970,9 @@ method parse*(this: IndentedCodeParser, doc: string, start: int): ParseResult {.
 proc parseIndentedCode*(doc: string, start: int): ParseResult =
   IndentedCodeParser().parse(doc, start)
 
-proc getSetextHeading*(s: string): tuple[level: int, doc: string, size: int] =
+proc getSetextHeading*(doc: string, start = 0): tuple[level: int, doc: string, size: int] =
+  var s = substr(doc, start, doc.len-1)
+  var pos = findFirstLine(doc, start)
   var size = s.firstLine.len
   var markerLen = 0
   var matches: array[1, string]
@@ -1002,7 +1004,7 @@ proc getSetextHeading*(s: string): tuple[level: int, doc: string, size: int] =
   return (level: level, doc: doc, size: size)
 
 method parse(this: SetextHeadingParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
-  let res = substr(doc, start, doc.len-1).getSetextHeading()
+  let res = getSetextHeading(doc, start)
   if res.size == -1: return ParseResult(token: nil, pos: -1)
   return ParseResult(
     token: Heading(

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -701,10 +701,11 @@ proc parseOrderedListItem*(doc: string, start=0, marker: var string, listItemDoc
         pos += size
         break
     elif listItemDoc.find(re"\n{2,}$") == -1:
-      var line = substr(doc, pos, doc.len-1).firstLine
-      if line.isContinuationText:
-        listItemDoc &= line
-        size = line.len
+      var firstLineSize = findFirstLine(doc, pos)
+      var firstLineEnd = pos + firstLineSize
+      if isContinuationText(doc, pos, firstLineEnd):
+        listItemDoc &= substr(doc, pos, firstLineEnd)
+        size = firstLineSize
       else:
         break
     else:
@@ -762,10 +763,11 @@ proc parseUnorderedListItem*(doc: string, start=0, marker: var string, listItemD
         pos += size
         break
     elif listItemDoc.find(re"\n{2,}$") == -1:
-      var line = substr(doc, pos, doc.len-1).firstLine
-      if line.isContinuationText:
-        listItemDoc &= line
-        size = line.len
+      var firstLineSize = findFirstLine(doc, pos)
+      var firstLineEnd = pos + firstLineSize
+      if isContinuationText(doc, pos, firstLineEnd):
+        listItemDoc &= substr(doc, pos, firstLineEnd)
+        size = firstLineSize
       else:
         break
     else:

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -364,8 +364,8 @@ proc preProcessing(state: State, token: Token) =
   token.doc = token.doc.replace("&#0;", "&#XFFFD;")
   token.doc = token.doc.replaceInitialTabs
 
-proc isBlank*(doc: string): bool =
-  doc.contains(re"^[ \t]*\n?$")
+proc isBlank*(doc: string, start: int = 0): bool =
+  doc.match(re"[ \t]*\n?$", start)
 
 proc findFirstLine*(doc: string, start: int): int =
   if start >= doc.len:
@@ -1509,13 +1509,13 @@ proc isContinuationText*(doc: string): bool =
 
   return true
 
-proc isUlEmptyListItem*(doc: string): bool =
-  doc.match(re"^ {0,3}(?:[\-+*]|\d+[.)])[ \t]*\n?$")
+proc isUlEmptyListItem*(doc: string, start: int = 0): bool =
+  doc.match(re" {0,3}(?:[\-+*]|\d+[.)])[ \t]*\n?$", start)
 
-proc isOlNo1ListItem*(doc: string): bool =
+proc isOlNo1ListItem*(doc: string, start: int = 0): bool =
   (
-    doc.contains(re" {0,3}\d+[.(][ \t]+[^\n]") and
-    not doc.contains(re" {0,3}1[.)]")
+    doc.contains(re" {0,3}\d+[.(][ \t]+[^\n]", start) and
+    not doc.contains(re" {0,3}1[.)]", start)
   )
 
 method parse*(this: ParagraphParser, doc: string, start: int): ParseResult =


### PR DESCRIPTION
The tactic is the same as #53. In this PR, I eliminate more substr calls in various procs.

Given [out2.txt](https://github.com/soasme/nim-markdown/files/5755244/out2.txt) provided in #48 , comparing to current HEAD, the run time has reduced from 0.5 to 0.23.

HEAD:
```
$ nim c -d:release src/markdown.nim && time ./src/markdown < /tmp/out2.txt
real	0m1.120s
user	0m0.474s
sys	0m0.012s
```
PR:
```
real	0m1.054s
user	0m0.229s
sys	0m0.014s
```