### PR TITLE
Performance improvement: remove firstLine & restLines calls.

### DIFF
--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -390,19 +390,6 @@ iterator findRestLines*(doc: string, start: int): tuple[start: int, stop: int] =
       yield (nextStart, nextEnd+1)
     nextStart = nextEnd + 1
 
-proc firstLine*(doc: string): string =
-  for line in doc.splitLines(keepEol=true):
-    return line
-  return ""
-
-iterator restLines*(doc: string): string =
-  var isRestLines = false
-  for line in doc.splitLines(keepEol=true):
-    if isRestLines:
-      yield line
-    else:
-      isRestLines = true
-
 proc escapeTag*(doc: string): string =
   ## Replace `<` and `>` to HTML-safe characters.
   ## Example::


### PR DESCRIPTION
Keep working on #48 and finally removes two bottleneck proc calls:
Before (HEAD):
```
$ nim c -d:release src/markdown.nim && time ./src/markdown < /tmp/out2.txt
real	0m1.054s
user	0m0.229s
sys	0m0.014s
```
After:
```
real	0m0.449s
user	0m0.160s
sys	0m0.012s
```