### PR TITLE
Combine Text tokens and preserve parse position, and remove deprecated `locks` pragma

### DIFF
--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -274,7 +274,7 @@ proc toStringSeq(tokens: DoublyLinkedList[Token]): seq[string];
 
 let skipParsing = ParseResult(token: nil, pos: -1)
 
-method parse*(this: Parser, doc: string, start: int): ParseResult {.base, locks: "unknown".} =
+method parse*(this: Parser, doc: string, start: int): ParseResult {.base.} =
   ParseResult(token: Token(), pos: doc.len)
 
 proc appendChild*(token: Token, child: Token) =
@@ -472,39 +472,39 @@ proc toSeq(tokens: DoublyLinkedList[Token]): seq[Token] =
   for token in tokens.items:
     result.add(token)
 
-method `$`*(token: Token): string {.base, locks: "unknown".} = ""
+method `$`*(token: Token): string {.base.} = ""
 
-method `$`*(token: CodeSpan): string {.locks: "unknown".} =
+method `$`*(token: CodeSpan): string =
   code(token.doc.escapeAmpersandChar.escapeTag.escapeQuote)
 
-method `$`*(token: SoftBreak): string {.locks: "unknown".}= "\n"
+method `$`*(token: SoftBreak): string = "\n"
 
-method `$`*(token: HardBreak): string {.locks: "unknown".} = br() & "\n"
+method `$`*(token: HardBreak): string = br() & "\n"
 
-method `$`*(token: Strikethrough): string {.locks: "unknown".} =
+method `$`*(token: Strikethrough): string =
   del(token.doc)
 
-method `$`*(token: ThematicBreak): string {.locks: "unknown".} =
+method `$`*(token: ThematicBreak): string =
   hr()
 
-method `$`*(token: Escape): string {.locks: "unknown".} =
+method `$`*(token: Escape): string =
   token.doc.escapeAmpersandSeq.escapeTag.escapeQuote
 
-method `$`*(token: InlineHtml): string {.locks: "unknown".} =
+method `$`*(token: InlineHtml): string =
   token.doc.escapeInvalidHTMLTag
 
-method `$`*(token: HtmlEntity): string {.locks: "unknown".} =
+method `$`*(token: HtmlEntity): string =
   token.doc.escapeHTMLEntity.escapeQuote
 
-method `$`*(token: Text): string {.locks: "unknown".} =
+method `$`*(token: Text): string =
   token.doc.escapeAmpersandSeq.escapeTag.escapeQuote
 
-method `$`*(token: AutoLink): string {.locks: "unknown".} =
+method `$`*(token: AutoLink): string =
   let href = token.url.escapeLinkUrl.escapeAmpersandSeq
   let text = token.text.escapeAmpersandSeq
   a(href=href, text)
 
-method `$`*(token: CodeBlock): string {.locks: "unknown".} =
+method `$`*(token: CodeBlock): string =
   var codeHTML = token.doc.escapeCode.escapeQuote
   if codeHTML != "" and not codeHTML.endsWith("\n"):
     codeHTML &= "\n"
@@ -515,7 +515,7 @@ method `$`*(token: CodeBlock): string {.locks: "unknown".} =
     let lang = fmt"language-{info}"
     pre(code(class=lang, codeHTML))
 
-method `$`*(token: HtmlBlock): string {.locks: "unknown".} =
+method `$`*(token: HtmlBlock): string =
   token.doc.strip(chars={'\n'})
 
 method `$`*(token: Link): string =
@@ -828,7 +828,7 @@ method parse*(this: OlParser, doc: string, start: int): ParseResult =
 proc getThematicBreak(doc: string, start: int = 0): tuple[size: int] =
   return (size: doc.matchLen(re(THEMATIC_BREAK_RE), start))
 
-method parse*(this: ThematicBreakParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: ThematicBreakParser, doc: string, start: int): ParseResult =
   let res = doc.getThematicBreak(start)
   if res.size == -1: return ParseResult(token: nil, pos: -1)
   return ParseResult(
@@ -882,7 +882,7 @@ proc parseTildeBlockCodeInfo*(doc: string, start: int = 0): tuple[info: string, 
     return (item, size)
   return ("", size)
 
-method parse*(this: FencedCodeParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: FencedCodeParser, doc: string, start: int): ParseResult =
   var pos = start
   var fenceRes = doc.getFence(start)
   if fenceRes.size == -1: return ParseResult(token: nil, pos: -1)
@@ -942,7 +942,7 @@ proc getIndentedCodeRestLines*(doc: string, start: int = 0): tuple[code: string,
       break
   return (code: code, size: size)
 
-method parse*(this: IndentedCodeParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: IndentedCodeParser, doc: string, start: int): ParseResult =
   var res = getIndentedCodeFirstLine(doc, start)
   if res.size == -1: return ParseResult(token: nil, pos: -1)
   var code = res.code
@@ -994,7 +994,7 @@ proc getSetextHeading*(doc: string, start = 0): tuple[level: int, doc: string, s
   let doc = substr(doc, start, start+size-markerLen-1).strip
   return (level: level, doc: doc, size: size)
 
-method parse(this: SetextHeadingParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse(this: SetextHeadingParser, doc: string, start: int): ParseResult =
   let res = getSetextHeading(doc, start)
   if res.size == -1: return ParseResult(token: nil, pos: -1)
   return ParseResult(
@@ -1017,7 +1017,7 @@ proc getAtxHeading*(s: string, start: int = 0): tuple[level: int, doc: string, s
   let doc = if matches[2] =~ re"#+": "" else: matches[2]
   return (level: level, doc: doc, size: size)
 
-method parse(this: AtxHeadingParser, doc: string, start: int = 0): ParseResult {.locks: "unknown".} =
+method parse(this: AtxHeadingParser, doc: string, start: int = 0): ParseResult =
   let res = doc.getAtxHeading(start)
   if res.size == -1: return ParseResult(token: nil, pos: -1)
   return ParseResult(
@@ -1028,7 +1028,7 @@ method parse(this: AtxHeadingParser, doc: string, start: int = 0): ParseResult {
     pos: start+res.size
   )
 
-method parse*(this: BlanklineParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: BlanklineParser, doc: string, start: int): ParseResult =
   let size = doc.matchLen(re(r"((?:\s*\n)+)"), start)
   if size == -1: return ParseResult(token: nil, pos: -1)
   let token = Token(doc: substr(doc, start, start+size-1))
@@ -1104,7 +1104,7 @@ proc parseTableAligns*(doc: string): tuple[aligns: seq[string], matched: bool] =
       aligns.add("")
   return (aligns, true)
 
-method parse*(this: HtmlTableParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: HtmlTableParser, doc: string, start: int): ParseResult =
   # Algorithm:
   # fail fast if less than 2 lines.
   # second line: /^[-:|][-:|\s]*$/
@@ -1291,7 +1291,7 @@ proc parseHtmlBlock(doc: string, start: int = 0): ParseResult =
     pos: start+pos
   )
 
-method parse*(this: HtmlBlockParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: HtmlBlockParser, doc: string, start: int): ParseResult =
   return parseHtmlBlock(doc, start)
 
 const rBlockquoteMarker = r"( {0,3}>)"
@@ -1577,10 +1577,10 @@ proc finalizeList*(state: State, token: Token) =
       if child of Paragraph:
         Paragraph(child).loose = loose
 
-method apply*(this: Token, state: State, res: ParseResult): ParseResult {.base, locks: "unknown".} =
+method apply*(this: Token, state: State, res: ParseResult): ParseResult {.base.} =
   res
 
-method apply*(this: Ul, state: State, res: ParseResult): ParseResult {.locks: "unknown".} =
+method apply*(this: Ul, state: State, res: ParseResult): ParseResult =
   state.finalizeList(res.token)
   res
 
@@ -1591,7 +1591,7 @@ method apply*(this: Ol, state: State, res: ParseResult): ParseResult =
 method apply*(this: Blockquote, state: State, res: ParseResult): ParseResult =
   state.parseContainerBlock(res.token)
 
-method apply*(this: Reference, state: State, res: ParseResult): ParseResult {.locks: "unknown".} =
+method apply*(this: Reference, state: State, res: ParseResult): ParseResult =
   if not state.references.contains(this.text):
     state.references[this.text] = this
   res
@@ -1610,17 +1610,17 @@ proc parseBlock(state: State, token: Token) =
     if res.pos == -1:
       raise newException(MarkdownError, fmt"unknown rule.")
 
-method parse*(this: TextParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: TextParser, doc: string, start: int): ParseResult =
   let token = Text(doc: substr(doc, start, start))
   return ParseResult(token: token, pos: start+1)
 
-method parse*(this: SoftBreakParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: SoftBreakParser, doc: string, start: int): ParseResult =
   let size = doc.matchLen(re" \n *", start)
   if size == -1: return skipParsing
   let token = SoftBreak()
   return ParseResult(token: token, pos: start+size)
 
-method parse*(this: AutoLinkParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: AutoLinkParser, doc: string, start: int): ParseResult =
   if doc[start] != '<':
     return skipParsing
 
@@ -1699,7 +1699,7 @@ proc scanInlineDelimiters*(doc: string, start: int, delimiter: var Delimiter) =
     delimiter.canOpen = isLeftFlanking
     delimiter.canClose = isRightFlanking
 
-method parse*(this: DelimiterParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: DelimiterParser, doc: string, start: int): ParseResult =
   if not {'*', '_'}.contains(doc[start]):
     return ParseResult(token: nil, pos: -1)
 
@@ -1994,7 +1994,7 @@ proc parseShortcutReferenceLink(doc: string, start: int, labelSlice: Slice[int])
   )
   return ParseResult(token: link, pos: labelSlice.b + 1)
 
-method parse*(this: LinkParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: LinkParser, doc: string, start: int): ParseResult =
   # Link should start with [
   if doc[start] != '[': return skipParsing
 
@@ -2125,7 +2125,7 @@ method apply*(this: Image, state: State, res: ParseResult): ParseResult =
   state.parseLeafBlockInlines(this)
   res
 
-method parse*(this: ImageParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: ImageParser, doc: string, start: int): ParseResult =
   # Image should start with ![
   if not doc.match(re"!\[", start): return skipParsing
 
@@ -2153,7 +2153,7 @@ method parse*(this: ImageParser, doc: string, start: int): ParseResult {.locks: 
   return doc.parseShortcutReferenceImage(start, labelSlice)
 
 const ENTITY = r"&(?:#x[a-f0-9]{1,6}|#[0-9]{1,7}|[a-z][a-z0-9]{1,31});"
-method parse*(this: HtmlEntityParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: HtmlEntityParser, doc: string, start: int): ParseResult =
   if doc[start] != '&': return skipParsing
 
   let regex = re(r"(" & ENTITY & ")", {RegexFlag.reIgnoreCase})
@@ -2173,7 +2173,7 @@ method parse*(this: HtmlEntityParser, doc: string, start: int): ParseResult {.lo
   )
   return ParseResult(token: token, pos: start+size)
 
-method parse*(this: EscapeParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: EscapeParser, doc: string, start: int): ParseResult =
   if doc[start] != '\\': return skipParsing
 
   let regex = re"\\([\\`*{}\[\]()#+\-.!_<>~|""$%&',/:;=?@^])"
@@ -2183,7 +2183,7 @@ method parse*(this: EscapeParser, doc: string, start: int): ParseResult {.locks:
   let token = Escape(doc: fmt"{doc[start+1]}")
   return ParseResult(token: token, pos: start+size)
 
-method parse*(this: InlineHtmlParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: InlineHtmlParser, doc: string, start: int): ParseResult =
   if doc[start] != '<': return skipParsing
 
   let regex = re("(" & HTML_TAG & ")", {RegexFlag.reIgnoreCase})
@@ -2195,13 +2195,13 @@ method parse*(this: InlineHtmlParser, doc: string, start: int): ParseResult {.lo
   let token = InlineHtml(doc: matches[0])
   return ParseResult(token: token, pos: start+size)
 
-method parse*(this: HardBreakParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: HardBreakParser, doc: string, start: int): ParseResult =
   if not {' ', '\\'}.contains(doc[start]): return skipParsing
   let size = doc.matchLen(re"((?: {2,}\n|\\\n)\s*)", start)
   if size == -1: return skipParsing
   return ParseResult(token: HardBreak(), pos: start+size)
 
-method parse*(this: CodeSpanParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: CodeSpanParser, doc: string, start: int): ParseResult =
   if doc[start] != '`': return skipParsing
 
   var matches: array[5, string]
@@ -2222,7 +2222,7 @@ method parse*(this: CodeSpanParser, doc: string, start: int): ParseResult {.lock
   let token = CodeSpan(doc: codeSpanVal)
   return ParseResult(token: token, pos: start+size)
 
-method parse*(this: StrikethroughParser, doc: string, start: int): ParseResult {.locks: "unknown".} =
+method parse*(this: StrikethroughParser, doc: string, start: int): ParseResult =
   if doc[start] != '~': return skipParsing
 
   var matches: array[5, string]

--- a/src/markdown.nim
+++ b/src/markdown.nim
@@ -502,7 +502,7 @@ method `$`*(token: HtmlEntity): string =
   token.doc.escapeHTMLEntity.escapeQuote
 
 method `$`*(token: Text): string =
-  token.doc.escapeAmpersandSeq.escapeTag.escapeQuote
+  token.doc.escapeAmpersandChar.escapeTag.escapeQuote
 
 method `$`*(token: AutoLink): string =
   let href = token.url.escapeLinkUrl.escapeAmpersandSeq
@@ -2550,3 +2550,4 @@ when isMainModule:
       config=readCLIOptions()
     )
   )
+


### PR DESCRIPTION
Preserving the parse positions means that it is possible to map the
output HTML to the original markdown document. This can be useful in
order to support parsing of sub-sections of the markdown, for example in
order to make live-editing possible. This also combines contiguous Text
tokens into a single Text token. This provides a small 1.3x speedup, and
a rather good 10x improvement in maximum memory usage (reported by
getMemMax) and a 100x improvement in the final tree size (reported by
getOccupiedMem) for parsing a largish 71k markdown document.